### PR TITLE
Add Flink 2.0 and Spark 4.1 upgrades to PR #4

### DIFF
--- a/kubernetes/aws/kafka-storage-class.yaml
+++ b/kubernetes/aws/kafka-storage-class.yaml
@@ -4,15 +4,15 @@ metadata:
   name: kafka
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
-provisioner: kubernetes.io/aws-ebs
-#provisioner: ebs.csi.aws.com
+# In-tree "kubernetes.io/aws-ebs" provisioner was removed in K8s 1.23+ and
+# is fully gone by 1.35. Use the AWS EBS CSI driver instead.
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
-  fsType: xfs
-  #csi.storage.k8s.io/fstype: xfs
+  csi.storage.k8s.io/fstype: xfs
   iops: "16000"
-  throughput: "1000" #MiB/s
+  throughput: "1000" # MiB/s
   #encrypted: "true"
-#reclaimPolicy: Retain #Delete
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/kubernetes/shuffle-flink/flink-configuration-configmap.yaml
+++ b/kubernetes/shuffle-flink/flink-configuration-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: flink
 data:
-  flink-conf.yaml: |+
+  config.yaml: |+
     jobmanager.rpc.address: flink-jobmanager
     taskmanager.numberOfTaskSlots: 1
     blob.server.port: 6124
@@ -14,6 +14,10 @@ data:
     queryable-state.proxy.ports: 6125
     jobmanager.memory.process.size: 4Gb
     taskmanager.memory.process.size: 4Gb
+    # Flink 2.x on Java 17+ requires these JVM module opens (the official
+    # Flink image sets them in its default config.yaml, but we override the
+    # whole /opt/flink/conf directory, so we must repeat them here).
+    env.java.opts.all: --add-exports=java.base/sun.net.util=ALL-UNNAMED --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true
     #metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
     metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
     metrics.reporter.prom.interval: 10 SECONDS

--- a/kubernetes/shuffle-flink/jobmanager-deployment.yaml
+++ b/kubernetes/shuffle-flink/jobmanager-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           configMap:
             name: flink-config
             items:
-              - key: flink-conf.yaml
-                path: flink-conf.yaml
+              - key: config.yaml
+                path: config.yaml
               - key: log4j-console.properties
                 path: log4j-console.properties

--- a/kubernetes/shuffle-flink/taskmanager-deployment.yaml
+++ b/kubernetes/shuffle-flink/taskmanager-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           configMap:
             name: flink-config
             items:
-              - key: flink-conf.yaml
-                path: flink-conf.yaml
+              - key: config.yaml
+                path: config.yaml
               - key: log4j-console.properties
                 path: log4j-console.properties

--- a/kubernetes/shuffle-sparkStructuredStreaming/spark-master-deployment.yaml
+++ b/kubernetes/shuffle-sparkStructuredStreaming/spark-master-deployment.yaml
@@ -28,14 +28,24 @@ spec:
           env:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "theodolite-kafka-kafka-bootstrap:9092"
+            - name: KAFKA_TOPIC_INPUT
+              value: "input"
+            - name: KAFKA_TOPIC_OUTPUT
+              value: "output"
             - name: MATCHER_ZIPF_NUM_RULES
               value: "1000000"
             - name: MATCHER_ZIPF_TOTAL_SELECTIVITY
               value: "0.2"
             - name: MATCHER_ZIPF_S
               value: "0.0"
+            - name: CONSUMER_OUTPUT_RATE
+              value: "10"
+            - name: CONSUMER_STATE_SIZE_BYTES
+              value: "32"
             - name: CONSUMER_INIT_COUNT_RANDOM
               value: "true"
+            - name: CONSUMER_INIT_COUNT_SEED
+              value: "8902763414119392010"
             # - name: SPARK_MAX_OFFSETS_PER_TRIGGER
             #   value: "10000000"
             - name: SPARK_EXECUTOR_MEMORY
@@ -58,7 +68,9 @@ spec:
                 --conf spark.driver.bindAddress=$POD_IP \
                 --conf spark.executor.memory=$SPARK_EXECUTOR_MEMORY \
                 --conf spark.sql.shuffle.partitions=$SPARK_SQL_SHUFFLE_PARTITIONS \
-                /shuffle-spark-1.0-SNAPSHOT.jar
+                --conf "spark.driver.extraJavaOptions=--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED" \
+                --conf "spark.executor.extraJavaOptions=--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED" \
+                /shuffle-spark-1.0-SNAPSHOT-all.jar
           ports:
             - containerPort: 4040
           resources:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -4,6 +4,12 @@ kafkaClient:
 kcat:
   enabled: true
 
+strimzi-kafka-operator:
+  createGlobalResources: true  # Required for rack-awareness
+  extraEnvs:
+    - name: STRIMZI_KUBERNETES_VERSION
+      value: "major=1,minor=33"
+
 strimzi:
   kafka:
     replicas: 3
@@ -11,9 +17,13 @@ strimzi:
       "auto.create.topics.enable": false
       "log.retention.ms": "7200000" # 2h
       "transaction.max.timeout.ms": "7200000" # 2h
-    jvmOptions: # Will become default with Theodolite v0.10
-      "-Xmx": null
-      "-Xms": null
+    # Note: Theodolite chart used to set "-Xms"/"-Xmx" to null here to let
+    # Strimzi auto-size the JVM heap, but newer Strimzi CRDs reject null
+    # for these fields (they must be strings). Leave jvmOptions unset so
+    # the chart's default string values apply. To override, use e.g.:
+    # jvmOptions:
+    #   "-Xms": "4G"
+    #   "-Xmx": "4G"
   zookeeper:
     replicas: 3
     zooEntrance:

--- a/shuffle-flink/build.gradle
+++ b/shuffle-flink/build.gradle
@@ -3,18 +3,18 @@
 
 plugins {
     id 'java'
-    id "application"
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
-    id 'com.google.cloud.tools.jib' version '3.3.1'
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.google.cloud.tools.jib' version '3.4.5'
 }
 
 application {
-    mainClass = "com.dynatrace.research.shufflebench.FlinkShuffle"
+    mainClass = 'com.dynatrace.research.shufflebench.FlinkShuffle'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
     withJavadocJar()
     withSourcesJar()
@@ -24,7 +24,11 @@ group = 'com.dynatrace'
 version = '1.0-SNAPSHOT'
 
 ext {
-    flinkVersion = '1.17.0'
+    flinkVersion = '2.0.0'
+    flinkKafkaConnectorVersion = '4.0.1-2.0'
+    log4jVersion = '2.24.3'
+    smallryeConfigVersion = '3.2.1'
+    hash4jVersion = '0.11.0'
 }
 
 repositories {
@@ -34,7 +38,7 @@ repositories {
 // NOTE: We cannot use "compileOnly" or "shadow" configurations since then we could not run code
 // in the IDE or with "gradle run". We also cannot exclude transitive dependencies from the
 // shadowJar yet (see https://github.com/johnrengelman/shadow/issues/159).
-// -> Explicitly define the // libraries we want to be included in the "flinkShadowJar" configuration!
+// -> Explicitly define the libraries we want to be included in the "flinkShadowJar" configuration!
 configurations {
     flinkShadowJar // dependencies which go into the shadowJar
     // always exclude these (also from transitive dependencies) since they are provided by Flink
@@ -43,6 +47,7 @@ configurations {
     flinkShadowJar.exclude group: 'org.slf4j'
     flinkShadowJar.exclude group: 'org.apache.logging.log4j'
 }
+
 dependencies {
     // Compile-time dependencies that should NOT be part of the
     // shadow (uber) jar and are provided in the lib folder of Flink
@@ -50,20 +55,19 @@ dependencies {
     implementation "org.apache.flink:flink-clients:${flinkVersion}"
     // Dependencies that should be part of the shadow jar, e.g.
     // connectors. These must be in the flinkShadowJar configuration!
-    flinkShadowJar "org.apache.flink:flink-connector-kafka:${flinkVersion}"
-    // flinkShadowJar "org.apache.flink:flink-statebackend-rocksdb:${flinkVersion}"
-    // flinkShadowJar "org.apache.flink:flink-metrics-prometheus:${flinkVersion}"
-    // flinkShadowJar "org.apache.flink:flink-runtime-web:${flinkVersion}" // For debugging
-    runtimeOnly 'org.apache.logging.log4j:log4j-api:2.19.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.19.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
+    flinkShadowJar "org.apache.flink:flink-connector-kafka:${flinkKafkaConnectorVersion}"
+    flinkShadowJar "org.apache.flink:flink-connector-base:${flinkVersion}"
+    runtimeOnly "org.apache.logging.log4j:log4j-api:${log4jVersion}"
+    runtimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     flinkShadowJar project(':commons')
-    flinkShadowJar 'io.smallrye.config:smallrye-config:3.2.1'
-    flinkShadowJar 'com.dynatrace.hash4j:hash4j:0.9.0'
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.1'
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.1'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
+    flinkShadowJar "io.smallrye.config:smallrye-config:${smallryeConfigVersion}"
+    flinkShadowJar "com.dynatrace.hash4j:hash4j:${hash4jVersion}"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
+
 // make compileOnly dependencies available for tests:
 sourceSets {
     main.compileClasspath += configurations.flinkShadowJar
@@ -84,15 +88,15 @@ shadowJar {
 
 jib {
     from {
-        image =  "flink:${flinkVersion}"
+        image = "flink:${flinkVersion}-java21"
         platforms {
             platform {
-                architecture = "amd64"
-                os = "linux"
+                architecture = 'amd64'
+                os = 'linux'
             }
             platform {
-                architecture = "arm64"
-                os = "linux"
+                architecture = 'arm64'
+                os = 'linux'
             }
         }
     }
@@ -116,3 +120,4 @@ jib {
         entrypoint = 'INHERIT'
     }
 }
+

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/AggregateFunction.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/AggregateFunction.java
@@ -8,23 +8,33 @@ import com.dynatrace.research.shufflebench.record.TimestampedRecord;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.util.Collector;
+import org.apache.flink.api.common.functions.OpenContext;
 
+/**
+ * Aggregates timestamped records per key using a {@link StatefulConsumer}.
+ */
 public class AggregateFunction
         extends KeyedProcessFunction<String, Tuple2<String, TimestampedRecord>, Tuple2<String, ConsumerEvent>> {
 
+    /** Stateful consumer used to update per-key state. */
     private final StatefulConsumer consumer;
 
+    /** Flink-managed state for the current key. */
     private ValueState<State> state;
 
+    /**
+     * Creates the keyed aggregation function.
+     *
+     * @param consumer stateful consumer used for state updates and output generation
+     */
     public AggregateFunction(StatefulConsumer consumer) {
         this.consumer = consumer;
     }
 
     @Override
-    public void open(Configuration parameters) {
+    public void open(OpenContext openContext) {
         state = super.getRuntimeContext().getState(new ValueStateDescriptor<>("state", State.class));
     }
 

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/FlinkShuffle.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/FlinkShuffle.java
@@ -5,6 +5,7 @@ import com.dynatrace.research.shufflebench.matcher.MatcherService;
 import com.dynatrace.research.shufflebench.matcher.SerializableMatcherService;
 import com.dynatrace.research.shufflebench.matcher.SimpleMatcherService;
 import com.dynatrace.research.shufflebench.record.*;
+import com.dynatrace.research.shufflebench.record.Record;
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.TypeHint;
@@ -27,6 +28,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Flink implementation of the ShuffleBench stream-processing pipeline.
+ */
 public class FlinkShuffle {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FlinkShuffle.class);
@@ -35,6 +39,9 @@ public class FlinkShuffle {
 
   private final StreamExecutionEnvironment env;
 
+  /**
+   * Creates and configures the Flink job from the benchmark configuration.
+   */
   public FlinkShuffle() {
     final Config config = ConfigProvider.getConfig();
 
@@ -76,17 +83,22 @@ public class FlinkShuffle {
 
     this.env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-    this.env.getConfig().registerTypeWithKryoSerializer(Record.class, new RecordKyroSerializer());
-    this.env.getConfig().registerTypeWithKryoSerializer(TimestampedRecord.class, new  TimestampedRecordKyroSerializer());
-    this.env.getConfig().registerTypeWithKryoSerializer(State.class, new StateKyroSerializer());
-    //this.env.getConfig().addDefaultKryoSerializer(Record.class, new RecordKyroSerializer());
-    this.env.getConfig().getRegisteredTypesWithKryoSerializers().forEach(
-            (type, serializer) -> LOGGER.info("Registered Kryo serializer for type '{}'.", type)
-    );
-    //this.env.getConfig().disableGenericTypes();
-    this.env.getConfig().disableAutoTypeRegistration();
-    this.env.getConfig().enableForceKryo();
+//    this.env.getConfig().registerTypeWithKryoSerializer(Record.class, new RecordKyroSerializer());
+//    this.env.getConfig().registerTypeWithKryoSerializer(TimestampedRecord.class, new  TimestampedRecordKyroSerializer());
+//    this.env.getConfig().registerTypeWithKryoSerializer(State.class, new StateKyroSerializer());
+//    //this.env.getConfig().addDefaultKryoSerializer(Record.class, new RecordKyroSerializer());
+//    this.env.getConfig().getRegisteredTypesWithKryoSerializers().forEach(
+//            (type, serializer) -> LOGGER.info("Registered Kryo serializer for type '{}'.", type)
+//    );
+//    //this.env.getConfig().disableGenericTypes();
+//    this.env.getConfig().disableAutoTypeRegistration();
+//    this.env.getConfig().enableForceKryo();
+//    this.env.getConfig().enableObjectReuse();
+
+    // Flink 2.x removed several legacy ExecutionConfig Kryo registration APIs.
+    // Keep object reuse enabled; revisit serializer tuning via Flink 2.x serialization config.
     this.env.getConfig().enableObjectReuse();
+
     this.env.setParallelism(parallelism);
     if (checkpointingEnabled) {
       // CheckpointingMode.EXACTLY_ONCE is the default
@@ -103,12 +115,8 @@ public class FlinkShuffle {
         .build();
 
     KafkaSinkBuilder<Tuple2<String, ConsumerEvent>> sinkBuilder = KafkaSink.<Tuple2<String,ConsumerEvent>>builder()
-        .setBootstrapServers(kafkaBootstrapServers)
-        .setRecordSerializer(KafkaRecordSerializationSchema.<Tuple2<String,ConsumerEvent>>builder()
-            .setTopic(kafkaOutputTopic)
-            .setKafkaKeySerializer(Tuple2StringKeyKafkaSerializer.class)
-            .setKafkaValueSerializer(Tuple2ConsumerEventValueKafkaSerializer.class)
-            .build());
+          .setBootstrapServers(kafkaBootstrapServers)
+          .setRecordSerializer(new ConsumerEventKafkaRecordSerializationSchema(kafkaOutputTopic));
     KafkaSink<Tuple2<String,ConsumerEvent>> sink;
     if (deliveryGuarantee.isPresent()) {
       sink = sinkBuilder
@@ -133,6 +141,9 @@ public class FlinkShuffle {
         .sinkTo(sink);
   }
 
+  /**
+   * Starts the configured Flink job.
+   */
   public void start() {
     try {
       this.env.execute();
@@ -141,6 +152,9 @@ public class FlinkShuffle {
     }
   }
 
+  /**
+   * Stops the Flink execution environment.
+   */
   public void stop() {
     try {
       this.env.close();
@@ -149,6 +163,11 @@ public class FlinkShuffle {
     }
   }
 
+  /**
+   * Application entry point.
+   *
+   * @param args command-line arguments, currently unused
+   */
   public static void main(String[] args) {
     FlinkShuffle flinkShuffle = new FlinkShuffle();
     flinkShuffle.start();

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/TimestampAssignerFunction.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/TimestampAssignerFunction.java
@@ -5,7 +5,16 @@ import com.dynatrace.research.shufflebench.record.TimestampedRecord;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
 
+/**
+ * Assigns Flink event timestamps to incoming records.
+ */
 public class TimestampAssignerFunction extends ProcessFunction<Record, TimestampedRecord> {
+
+    /**
+     * Creates a timestamp assigner function.
+     */
+    public TimestampAssignerFunction() {
+    }
 
     @Override
     public void processElement(Record record, Context ctx, Collector<TimestampedRecord> out) throws Exception {

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/ConsumerEventKafkaRecordSerializationSchema.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/ConsumerEventKafkaRecordSerializationSchema.java
@@ -1,0 +1,43 @@
+package com.dynatrace.research.shufflebench.record;
+
+import com.dynatrace.research.shufflebench.consumer.ConsumerEvent;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import javax.annotation.Nullable;
+
+public class ConsumerEventKafkaRecordSerializationSchema
+        implements KafkaRecordSerializationSchema<Tuple2<String, ConsumerEvent>> {
+
+    private final String topic;
+    private transient StringSerializer keySerializer;
+    private transient ConsumerEventSerde.ConsumerEventSerializer valueSerializer;
+
+    public ConsumerEventKafkaRecordSerializationSchema(String topic) {
+        this.topic = topic;
+    }
+
+    private void ensureInitialized() {
+        if (keySerializer == null) {
+            keySerializer = new StringSerializer();
+        }
+        if (valueSerializer == null) {
+            valueSerializer = new ConsumerEventSerde.ConsumerEventSerializer();
+        }
+    }
+
+    @Nullable
+    @Override
+    public ProducerRecord<byte[], byte[]> serialize(
+            Tuple2<String, ConsumerEvent> element,
+            KafkaSinkContext context,
+            Long timestamp) {
+        ensureInitialized();
+        byte[] key = keySerializer.serialize(topic, element.f0);
+        byte[] value = valueSerializer.serialize(topic, element.f1);
+        return new ProducerRecord<>(topic, key, value);
+    }
+}
+

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/ConsumerEventSerde.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/ConsumerEventSerde.java
@@ -5,7 +5,16 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
+/**
+ * Kafka serde for {@link ConsumerEvent} values.
+ */
 public class ConsumerEventSerde implements Serde<ConsumerEvent> {
+
+  /**
+   * Creates a consumer-event serde.
+   */
+  public ConsumerEventSerde() {
+  }
 
   @Override
   public Serializer<ConsumerEvent> serializer() {
@@ -17,7 +26,16 @@ public class ConsumerEventSerde implements Serde<ConsumerEvent> {
     return new ConsumerEventDeserializer();
   }
 
+  /**
+   * Serializer for {@link ConsumerEvent} instances.
+   */
   public static class ConsumerEventSerializer implements Serializer<ConsumerEvent> {
+
+    /**
+     * Creates a consumer-event serializer.
+     */
+    public ConsumerEventSerializer() {
+    }
 
     @Override
     public byte[] serialize(String topic, ConsumerEvent event) {
@@ -26,7 +44,16 @@ public class ConsumerEventSerde implements Serde<ConsumerEvent> {
 
   }
 
+  /**
+   * Deserializer for {@link ConsumerEvent} instances.
+   */
   public static class ConsumerEventDeserializer implements Deserializer<ConsumerEvent> {
+
+    /**
+     * Creates a consumer-event deserializer.
+     */
+    public ConsumerEventDeserializer() {
+    }
 
     @Override
     public ConsumerEvent deserialize(String topic, byte[] data) {

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/RecordKyroSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/RecordKyroSerializer.java
@@ -7,22 +7,33 @@ import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
 
-public class RecordKyroSerializer extends Serializer<Record> implements Serializable {
+/**
+ * Kryo serializer for benchmark {@link com.dynatrace.research.shufflebench.record.Record} values.
+ */
+public class RecordKyroSerializer extends Serializer<com.dynatrace.research.shufflebench.record.Record> implements Serializable {
 
   private static final long serialVersionUID = 728071037176839227L;
 
+  /**
+   * Creates a record Kryo serializer.
+   */
+  public RecordKyroSerializer() {
+  }
+
   @Override
-  public void write(Kryo kryo, Output output, Record record) {
+  public void write(Kryo kryo, Output output, com.dynatrace.research.shufflebench.record.Record record) {
     final byte[] data = record.getData();
     output.writeInt(data.length);
     output.writeBytes(data);
   }
 
   @Override
-  public Record read(Kryo kryo, Input input, Class<Record> type) {
+  public com.dynatrace.research.shufflebench.record.Record read(
+          Kryo kryo,
+          Input input,
+          Class<? extends com.dynatrace.research.shufflebench.record.Record> type) {
     final int length = input.readInt();
     final byte[] bytes = input.readBytes(length);
-    return new Record(bytes);
+    return new com.dynatrace.research.shufflebench.record.Record(bytes);
   }
-
 }

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/RecordSerde.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/RecordSerde.java
@@ -4,7 +4,16 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
+/**
+ * Kafka serde for {@link Record} values.
+ */
 public class RecordSerde implements Serde<Record> {
+
+  /**
+   * Creates a record serde.
+   */
+  public RecordSerde() {
+  }
 
   @Override
   public Serializer<Record> serializer() {
@@ -16,7 +25,16 @@ public class RecordSerde implements Serde<Record> {
     return new RecordDeserializer();
   }
 
+  /**
+   * Serializer for {@link Record} instances.
+   */
   public static class RecordSerializer implements Serializer<Record> {
+
+    /**
+     * Creates a record serializer.
+     */
+    public RecordSerializer() {
+    }
 
     @Override
     public byte[] serialize(String topic, Record record) {
@@ -25,7 +43,16 @@ public class RecordSerde implements Serde<Record> {
 
   }
 
+  /**
+   * Deserializer for {@link Record} instances.
+   */
   public static class RecordDeserializer implements Deserializer<Record> {
+
+    /**
+     * Creates a record deserializer.
+     */
+    public RecordDeserializer() {
+    }
 
     @Override
     public Record deserialize(String topic, byte[] data) {

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/StateKyroSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/StateKyroSerializer.java
@@ -8,9 +8,18 @@ import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
 
+/**
+ * Kryo serializer for {@link State} values.
+ */
 public class StateKyroSerializer extends Serializer<State> implements Serializable {
 
   private static final long serialVersionUID = 728071037176839228L;
+
+  /**
+   * Creates a state Kryo serializer.
+   */
+  public StateKyroSerializer() {
+  }
 
   @Override
   public void write(Kryo kryo, Output output, State state) {
@@ -20,7 +29,7 @@ public class StateKyroSerializer extends Serializer<State> implements Serializab
   }
 
   @Override
-  public State read(Kryo kryo, Input input, Class<State> type) {
+  public State read(Kryo kryo, Input input, Class<? extends State> type) {
     final int length = input.readInt();
     final byte[] bytes = input.readBytes(length);
     return new State(bytes);

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/StateSerde.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/StateSerde.java
@@ -5,7 +5,16 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
+/**
+ * Kafka serde for {@link State} values.
+ */
 public class StateSerde implements Serde<State> {
+
+  /**
+   * Creates a state serde.
+   */
+  public StateSerde() {
+  }
 
   @Override
   public Serializer<State> serializer() {
@@ -17,7 +26,16 @@ public class StateSerde implements Serde<State> {
     return new StateDeserializer();
   }
 
+  /**
+   * Serializer for {@link State} instances.
+   */
   public static class StateSerializer implements Serializer<State> {
+
+    /**
+     * Creates a state serializer.
+     */
+    public StateSerializer() {
+    }
 
     @Override
     public byte[] serialize(String topic, State state) {
@@ -26,7 +44,16 @@ public class StateSerde implements Serde<State> {
 
   }
 
+  /**
+   * Deserializer for {@link State} instances.
+   */
   public static class StateDeserializer implements Deserializer<State> {
+
+    /**
+     * Creates a state deserializer.
+     */
+    public StateDeserializer() {
+    }
 
     @Override
     public State deserialize(String topic, byte[] data) {

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/TimestampedRecordKyroSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/TimestampedRecordKyroSerializer.java
@@ -7,9 +7,18 @@ import com.esotericsoftware.kryo.io.Output;
 
 import java.io.Serializable;
 
+/**
+ * Kryo serializer for {@link TimestampedRecord} values.
+ */
 public class TimestampedRecordKyroSerializer extends Serializer<TimestampedRecord> implements Serializable {
 
   private static final long serialVersionUID = 728071037176839227L;
+
+  /**
+   * Creates a timestamped-record Kryo serializer.
+   */
+  public TimestampedRecordKyroSerializer() {
+  }
 
   @Override
   public void write(Kryo kryo, Output output, TimestampedRecord record) {
@@ -20,7 +29,7 @@ public class TimestampedRecordKyroSerializer extends Serializer<TimestampedRecor
   }
 
   @Override
-  public TimestampedRecord read(Kryo kryo, Input input, Class<TimestampedRecord> type) {
+  public TimestampedRecord read(Kryo kryo, Input input, Class<? extends TimestampedRecord> type) {
     final long timestamp = input.readLong();
     final int length = input.readInt();
     final byte[] data = input.readBytes(length);

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2ConsumerEventValueKafkaSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2ConsumerEventValueKafkaSerializer.java
@@ -7,8 +7,14 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
+/**
+ * Kafka serializer for the value component of {@code Tuple2<String, ConsumerEvent>} records.
+ */
 public class Tuple2ConsumerEventValueKafkaSerializer extends Tuple2ValueKafkaSerializer<ConsumerEvent> {
 
+    /**
+     * Creates a tuple serializer for consumer-event values.
+     */
     public Tuple2ConsumerEventValueKafkaSerializer() {
         super(new ConsumerEventSerde.ConsumerEventSerializer());
     }

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2KeyKafkaSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2KeyKafkaSerializer.java
@@ -6,10 +6,20 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
+/**
+ * Delegating Kafka serializer for the key component of a Flink {@link Tuple2}.
+ *
+ * @param <T> key type
+ */
 public class Tuple2KeyKafkaSerializer<T> implements Serializer<Tuple2<T,?>> {
 
     private final Serializer<T> keySerializer;
 
+    /**
+     * Creates a tuple-key serializer.
+     *
+     * @param keySerializer serializer used for the first tuple field
+     */
     public Tuple2KeyKafkaSerializer(Serializer<T> keySerializer) {
         this.keySerializer = keySerializer;
     }

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2StringKeyKafkaSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2StringKeyKafkaSerializer.java
@@ -8,8 +8,14 @@ import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Map;
 
+/**
+ * Kafka serializer for the string-key field of a {@code Tuple2<String, ?>}.
+ */
 public class Tuple2StringKeyKafkaSerializer extends Tuple2KeyKafkaSerializer<String> {
 
+    /**
+     * Creates a tuple serializer for string keys.
+     */
     public Tuple2StringKeyKafkaSerializer() {
         super(new StringSerializer());
     }

--- a/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2ValueKafkaSerializer.java
+++ b/shuffle-flink/src/main/java/com/dynatrace/research/shufflebench/record/Tuple2ValueKafkaSerializer.java
@@ -6,10 +6,20 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
+/**
+ * Delegating Kafka serializer for the value component of a Flink {@link Tuple2}.
+ *
+ * @param <T> value type
+ */
 public class Tuple2ValueKafkaSerializer<T> implements Serializer<Tuple2<?, T>> {
 
     private final Serializer<T> valueSerializer;
 
+    /**
+     * Creates a tuple-value serializer.
+     *
+     * @param valueSerializer serializer used for the second tuple field
+     */
     public Tuple2ValueKafkaSerializer(Serializer<T> valueSerializer) {
         this.valueSerializer = valueSerializer;
     }

--- a/shuffle-spark/Dockerfile
+++ b/shuffle-spark/Dockerfile
@@ -1,32 +1,78 @@
-ARG java_image_tag=11-jre
+FROM ubuntu:22.04
 
-FROM openjdk:11
+# Set environment variables for Spark and Hadoop versions
+ENV SPARK_VERSION=4.1.1
+ENV HADOOP_VERSION=3.4.2
 
-# define spark and hadoop versions
-ENV SPARK_VERSION=3.4.1
-ENV HADOOP_VERSION=3.3.1
+# Set environment variables for non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
 
-# download and install hadoop
+# Update and install required packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    wget \
+    tar \
+    bash \
+    openjdk-21-jre-headless \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Verify Java installation
+RUN java --version
+
+# Set JAVA_HOME environment variable
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+# Install Hadoop
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
-        tar -zx hadoop-${HADOOP_VERSION}/lib/native && \
+    curl -fSL --retry 5 --retry-delay 10 --retry-all-errors \
+        https://dlcdn.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz \
+        -o hadoop.tar.gz && \
+    tar -xzf hadoop.tar.gz && \
+    rm hadoop.tar.gz && \
     ln -s hadoop-${HADOOP_VERSION} hadoop && \
-    echo Hadoop ${HADOOP_VERSION} native libraries installed in /opt/hadoop/lib/native
-RUN export HADOOP_COMMON_LIB_NATIVE_DIR="/opt/hadoop/lib/native"
-# download and install spark
+    echo "Hadoop ${HADOOP_VERSION} installed in /opt"
+
+# Set Hadoop native library path
+ENV HADOOP_COMMON_LIB_NATIVE_DIR="/opt/hadoop/lib/native"
+
+# Install Spark
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz | \
-        tar -zx && \
+    curl -fSL --retry 5 --retry-delay 10 --retry-all-errors \
+        https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+        -o spark.tgz && \
+    tar -xzf spark.tgz && \
+    rm spark.tgz && \
     ln -s spark-${SPARK_VERSION}-bin-hadoop3 spark && \
-    echo Spark ${SPARK_VERSION} installed in /opt
+    echo "Spark ${SPARK_VERSION} installed in /opt"
 
-COPY build/libs/shuffle-spark-1.0-SNAPSHOT.jar .
 
-ADD common.sh spark-master spark-worker /
-RUN cd /
-RUN chmod +x spark-master
-RUN chmod +x spark-worker
+# Copy application JAR and scripts
+COPY build/libs/shuffle-spark-1.0-SNAPSHOT-all.jar /
+COPY --chmod=0755 common.sh /common.sh
+COPY --chmod=0755 spark-master /spark-master
+COPY --chmod=0755 spark-worker /spark-worker
+
+# Make scripts executable
+RUN chmod +x spark-master spark-worker
+
+# Add Spark configuration
 ADD spark-defaults.conf /opt/spark/conf/spark-defaults.conf
-ENV PATH $PATH:/opt/spark/bin
+
+# Update PATH to include Spark binaries
+ENV PATH=$PATH:/opt/spark/bin
+
+# Set the working directory
+WORKDIR /
+
+# Default command (optional)
+CMD ["/spark-master"]
+
+# Default to env-var config unless explicitly enabled.
+# Set USE_MICROPROFILE_CONFIG=true only when a ConfigProviderResolver is on the classpath.
+ENV USE_MICROPROFILE_CONFIG=false
+
+# Build marker to verify deployed image (override at build time, e.g. --build-arg IMAGE_BUILD_ID=...)
+ENV IMAGE_BUILD_ID=local-dev

--- a/shuffle-spark/README.md
+++ b/shuffle-spark/README.md
@@ -1,0 +1,65 @@
+# ShuffleBench — Spark (Structured Streaming) implementation
+
+Spark 4.1.1 / Scala 2.13 / Java 21 implementation of the ShuffleBench pipeline.
+
+## Configuration
+
+Configuration is read from MicroProfile Config (`META-INF/microprofile-config.properties`)
+when `USE_MICROPROFILE_CONFIG=true`, otherwise from environment variables.
+Each property maps to an env var by upper-casing the key and replacing `.`/`-` with `_`,
+e.g. `kafka.bootstrap.servers` → `KAFKA_BOOTSTRAP_SERVERS`.
+
+### Streaming trigger
+
+The query trigger is selectable at runtime. **Default: Spark's standard micro-batch
+trigger** (no explicit `.trigger(...)` call), matching the original benchmark behavior.
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `spark.trigger.mode` | `SPARK_TRIGGER_MODE` | `default` | One of `default`, `processing`, `continuous`, `realtime`. |
+| `spark.trigger.interval` | `SPARK_TRIGGER_INTERVAL` | – | Required when mode ≠ `default`, e.g. `200 milliseconds`. |
+| `spark.trigger.realtime` | `SPARK_TRIGGER_REALTIME` | – | Legacy fallback for the realtime interval. |
+
+Mode behavior:
+
+- `default` — no explicit trigger; Spark fires a new micro-batch as soon as the
+  previous one finishes (original benchmark behavior).
+- `processing` — `Trigger.ProcessingTime(interval)`.
+- `continuous` — `Trigger.Continuous(interval)`.
+- `realtime` — `Trigger.RealTime(interval)` (Spark 4.x real-time mode).
+
+Examples — enabling realtime:
+
+```sh
+# Environment variables (Docker / Kubernetes)
+-e SPARK_TRIGGER_MODE=realtime -e SPARK_TRIGGER_INTERVAL="200 milliseconds"
+
+# JVM system properties (local runs)
+-Dspark.trigger.mode=realtime -Dspark.trigger.interval="200 milliseconds"
+```
+
+If a non-`default` mode is selected without an interval, the application fails
+fast with a clear error.
+
+### Other Kafka/source knobs
+
+| Property | Description |
+|---|---|
+| `kafka.bootstrap.servers` | Kafka bootstrap servers. |
+| `kafka.topic.input` / `kafka.topic.output` | Input/output topics. |
+| `spark.max.offsets.per.trigger` | Optional Kafka source `maxOffsetsPerTrigger`. |
+| `spark.min.offsets.per.trigger` | Optional Kafka source `minOffsetsPerTrigger`. |
+
+## Build & run
+
+```sh
+# Build the shaded jar
+./gradlew :shuffle-spark:shadowJar
+
+# Build the container image
+docker build -t <registry>/shufflebench/shufflebench-spark shuffle-spark/
+```
+
+The Dockerfile uses `openjdk-21-jre-headless`, Spark 4.1.0 and Hadoop 3.4.2.
+Required `--add-opens` JVM flags for Java 21 are already set in `spark-defaults.conf`.
+

--- a/shuffle-spark/build.gradle
+++ b/shuffle-spark/build.gradle
@@ -1,13 +1,22 @@
-// gradle shadowjar -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+// gradle shadowJar -Dorg.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
+
+buildscript {
+    dependencies {
+        classpath 'org.ow2.asm:asm:9.7'
+        classpath 'org.ow2.asm:asm-commons:9.7'
+    }
+}
+
 plugins {
     id 'java'
-    id "application"
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'application'
+    id 'scala'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
     withJavadocJar()
     withSourcesJar()
@@ -17,11 +26,25 @@ group = 'com.dynatrace'
 version = '1.0-SNAPSHOT'
 
 application {
-    mainClass = "com.dynatrace.research.shufflebench.SparkStructuredStreamingShuffle"
+    mainClass = 'com.dynatrace.research.shufflebench.SparkStructuredStreamingShuffle'
+    applicationDefaultJvmArgs = [
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED'
+    ]
 }
 
 ext {
-    sparkVersion = '3.4.1'
+    sparkVersion = '4.1.1'
+    sparkKafkaClientsVersion = '3.9.1'
+    log4jVersion = '2.24.3'
+    smallryeConfigVersion = '3.2.1'
+    hash4jVersion = '0.11.0'
+    typesafeConfigVersion = '1.4.1'
+    jacksonDatabindVersion = '2.16.1'
 }
 
 repositories {
@@ -31,33 +54,32 @@ repositories {
 dependencies {
     implementation project(':commons')
 
-    // Spark dependencies
-    implementation "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    implementation "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    implementation "org.apache.spark:spark-streaming_2.12:${sparkVersion}"
-    implementation "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
+    // Spark dependencies (Scala 2.13 build)
+    implementation "org.apache.spark:spark-core_2.13:${sparkVersion}"
+    implementation "org.apache.spark:spark-sql_2.13:${sparkVersion}"
+    implementation "org.apache.spark:spark-streaming_2.13:${sparkVersion}"
+    implementation "org.apache.spark:spark-sql-kafka-0-10_2.13:${sparkVersion}"
 
     // Kafka dependencies
-    implementation 'org.apache.kafka:kafka-clients:3.5.0'
+    implementation "org.apache.kafka:kafka-clients:${sparkKafkaClientsVersion}"
+
     // Other dependencies
-    implementation 'com.typesafe:config:1.4.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
+    implementation "com.typesafe:config:${typesafeConfigVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    implementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
+    implementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4jVersion}"
+    implementation "io.smallrye.config:smallrye-config:${smallryeConfigVersion}"
+    implementation "com.dynatrace.hash4j:hash4j:${hash4jVersion}"
 
-    implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
-    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0'
-    implementation 'io.smallrye.config:smallrye-config:3.2.1'
-    implementation 'com.dynatrace.hash4j:hash4j:0.9.0'
-
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.1'
-    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.1'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
-tasks.register("allJar", com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+
+tasks.register('allJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
     manifest {
-        attributes "Main-Class": "shadow_test.Main"
-        exclude 'META-INF/*.DSA'
-        exclude 'META-INF/*.SF'
+        attributes 'Main-Class': 'com.dynatrace.research.shufflebench.SparkStructuredStreamingShuffle'
     }
 
     from sourceSets.main.output
@@ -67,24 +89,33 @@ tasks.register("allJar", com.github.jengelman.gradle.plugins.shadow.tasks.Shadow
 
     mergeServiceFiles()
 
-    with jar
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
 }
+
 test {
     useJUnitPlatform()
+    jvmArgs = [
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED'
+    ]
 }
+
 shadowJar {
     zip64 = true
     mergeServiceFiles()
 
-    // relocate pravega client's dependencies to minimize conflicts
-    relocate "org.apache.commons", "io.pravega.shaded.org.apache.commons"
-    relocate "com.google", "io.pravega.shaded.com.google"
-    relocate "io.grpc", "io.pravega.shaded.io.grpc"
-    relocate "com.squareup.okhttp", "io.pravega.shaded.com.squareup.okhttp"
-    relocate "okio", "io.pravega.shaded.okio"
-    relocate "io.opencensus", "io.pravega.shaded.io.opencensus"
-    relocate "io.netty", "io.pravega.shaded.io.netty"
-    relocate "com.fasterxml.jackson", "io.pravega.shaded.com.fasterxml.jackson"
-    relocate 'META-INF/native/libnetty', 'META-INF/native/libio_pravega_shaded_netty'
-    relocate 'META-INF/native/netty', 'META-INF/native/io_pravega_shaded_netty'
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
+    exclude 'META-INF/*.SF'
+
+    manifest {
+        attributes 'Main-Class': 'com.dynatrace.research.shufflebench.SparkStructuredStreamingShuffle'
+    }
 }
+

--- a/shuffle-spark/spark-defaults.conf
+++ b/shuffle-spark/spark-defaults.conf
@@ -1,2 +1,4 @@
 spark.master spark://spark-master:7077
 spark.driver.extraLibraryPath /opt/hadoop/lib/native
+spark.driver.extraJavaOptions --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+spark.executor.extraJavaOptions --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED

--- a/shuffle-spark/spark-master
+++ b/shuffle-spark/spark-master
@@ -2,6 +2,25 @@
 
 . /common.sh
 
-echo "$(hostname -i) spark-master" >> /etc/hosts
+MASTER_HOST="${SPARK_MASTER_HOST:-0.0.0.0}"
+MASTER_PORT="${SPARK_MASTER_PORT:-7077}"
+WEBUI_PORT="${SPARK_MASTER_WEBUI_PORT:-8080}"
 
-/opt/spark/bin/spark-class org.apache.spark.deploy.master.Master --ip spark-master --port 7077 --webui-port 8080
+echo "Image build id: ${IMAGE_BUILD_ID:-unknown}"
+
+# Only add /etc/hosts entry when a non-wildcard host is provided
+if [ "${MASTER_HOST}" != "0.0.0.0" ]; then
+  echo "$(hostname -i) ${MASTER_HOST}" >> /etc/hosts
+fi
+
+echo "Hadoop version:"
+/opt/hadoop/bin/hadoop version | head -n 1
+
+echo "Spark version:"
+/opt/spark/bin/spark-submit --version | head -n 1
+
+/opt/spark/bin/spark-class org.apache.spark.deploy.master.Master \
+  --host "${MASTER_HOST}" \
+  --port "${MASTER_PORT}" \
+  --webui-port "${WEBUI_PORT}"
+

--- a/shuffle-spark/src/main/java/com/dynatrace/research/shufflebench/CustomKryoRegistrator.java
+++ b/shuffle-spark/src/main/java/com/dynatrace/research/shufflebench/CustomKryoRegistrator.java
@@ -2,6 +2,7 @@ package com.dynatrace.research.shufflebench;
 
 import com.dynatrace.research.shufflebench.consumer.State;
 import com.dynatrace.research.shufflebench.record.*;
+import com.dynatrace.research.shufflebench.record.Record;
 import com.esotericsoftware.kryo.Kryo;
 import org.apache.spark.serializer.KryoRegistrator;
 

--- a/shuffle-spark/src/main/java/com/dynatrace/research/shufflebench/SparkStructuredStreamingShuffle.java
+++ b/shuffle-spark/src/main/java/com/dynatrace/research/shufflebench/SparkStructuredStreamingShuffle.java
@@ -1,27 +1,34 @@
+/*
+* Runs on IntelliJ require the following VM options (to run in Java 21):
+* --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+*  */
+
 package com.dynatrace.research.shufflebench;
 
 import com.dynatrace.research.shufflebench.consumer.*;
 import com.dynatrace.research.shufflebench.matcher.MatcherService;
-import com.dynatrace.research.shufflebench.matcher.SerializableMatcherService;
 import com.dynatrace.research.shufflebench.matcher.SimpleMatcherService;
 import com.dynatrace.research.shufflebench.record.TimestampedRecord;
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.FlatMapGroupsWithStateFunction;
 import org.apache.spark.api.java.function.MapFunction;
-import org.apache.spark.internal.config.Kryo;
+import org.apache.spark.sql.execution.streaming.RealTimeTrigger;
 import org.apache.spark.sql.streaming.*;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import scala.Tuple2;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
+
 public class SparkStructuredStreamingShuffle {
 
     private static final String APPLICATION_ID = "shufflebench-sparkStructuredStreaming";
@@ -29,115 +36,389 @@ public class SparkStructuredStreamingShuffle {
     public static void main(String[] args) throws StreamingQueryException, TimeoutException {
 
         SparkSession spark = SparkSession.builder()
+                //.master("local[1]")
                 .appName(APPLICATION_ID)
-                .config(Kryo.KRYO_REGISTRATION_REQUIRED().key(), true)
-                .config(Kryo.KRYO_USER_REGISTRATORS().key(), CustomKryoRegistrator.class.getName())
-                .config("spark.sql.streaming.stateStore.providerClass", "org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider")
+                .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+                .config("spark.kryo.registrator", CustomKryoRegistrator.class.getName())
+                .config("spark.sql.streaming.stateStore.providerClass",
+                        "org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider")
+                .config("spark.serializer.objectStreamReset", 0)
+                .config("spark.sql.streaming.metricsEnabled", "false")
+                //.config("","false")
+
                 .getOrCreate();
+        //Config config = ConfigProviderResolver.instance().getConfig();
+        // Try to load MicroProfile Config, but fall back to environment variables
+        Config config = loadMicroProfileConfig();
+        SmallRyeConfig smallRyeConfig = tryUnwrapSmallRye(config);
 
-        final Config config = ConfigProvider.getConfig();
-        final SmallRyeConfig smallRyeConfig = config.unwrap(SmallRyeConfig.class);
-
-        final String kafkaBootstrapServers = config.getValue("kafka.bootstrap.servers", String.class);
-        final String kafkaInputTopic = config.getValue("kafka.topic.input", String.class);
-        final String kafkaOutputTopic = config.getValue("kafka.topic.output", String.class);
-
-        Optional<Integer> maxOffsetsPerTrigger = config.getOptionalValue("spark.max.offsets.per.trigger", Integer.class);
+        final String kafkaBootstrapServers = getRequiredString(config, "kafka.bootstrap.servers");
+        final String kafkaInputTopic = getRequiredString(config, "kafka.topic.input");
+        final String kafkaOutputTopic = getRequiredString(config, "kafka.topic.output");
+        // Trigger configuration:
+        //   spark.trigger.mode      = default | processing | continuous | realtime   (default: "default" = Spark micro-batch)
+        //   spark.trigger.interval  = e.g. "200 milliseconds"  (used by processing/continuous/realtime)
+        //   spark.trigger.realtime  = legacy fallback for the realtime interval
+        final String sparkTriggerMode = getOptionalString(config, "spark.trigger.mode").orElse("default");
+        final String sparkTriggerInterval = getOptionalString(config, "spark.trigger.interval")
+                .or(() -> getOptionalString(config, "spark.trigger.realtime"))
+                .orElse(null);
+        Optional<Integer> maxOffsetsPerTrigger = getOptionalInt(config, "spark.max.offsets.per.trigger");
+        Optional<Integer> minOffsetsPerTrigger = getOptionalInt(config, "spark.min.offsets.per.trigger");
         DataStreamReader kafkaReader = spark.readStream()
                 .format("kafka")
                 .option("kafka.bootstrap.servers", kafkaBootstrapServers)
                 .option("subscribe", kafkaInputTopic)
                 .option("startingOffsets", "latest");
+
         if (maxOffsetsPerTrigger.isPresent()) {
             kafkaReader = kafkaReader.option("maxOffsetsPerTrigger", maxOffsetsPerTrigger.get());
         }
+        if (minOffsetsPerTrigger.isPresent()) {
+            kafkaReader = kafkaReader.option("minOffsetsPerTrigger", minOffsetsPerTrigger.get());
+        }
+
         final Dataset<Row> kafkaStream = kafkaReader
                 .load()
                 .select("value", "timestamp");
 
+        // Extract config values to local final variables (these ARE serializable)
         final Map<Double, Integer> selectivities =
-                smallRyeConfig.getOptionalValues("matcher.selectivities", Double.class, Integer.class).orElse(null);
-        final double totalSelectivity = config.getValue("matcher.zipf.total.selectivity", Double.class);
-        final int numRules = config.getValue("matcher.zipf.num.rules", Integer.class);
-        final double s = config.getValue("matcher.zipf.s", Double.class);
-        final MatcherService<TimestampedRecord> matcherService = new SerializableMatcherService<>(
-                () -> {
-                    if (selectivities != null) {
-                        return SimpleMatcherService.createFromFrequencyMap(selectivities, 0x2e3fac4f58fc98b4L);
-                    } else {
-                        return SimpleMatcherService.createFromZipf(
-                                numRules,
-                                totalSelectivity,
-                                s,
-                                0x2e3fac4f58fc98b4L);
-                    }
-                });
-        final int outputRate = config.getValue("consumer.output.rate", Integer.class);
-        final int stateSizeBytes = config.getValue("consumer.state.size.bytes", Integer.class);
-        final boolean initCountRandom = config.getValue("consumer.init.count.random", Boolean.class);
-        final long initCountSeed = config.getValue("consumer.init.count.seed", Long.class);
-
-        final StatefulConsumer consumer = new SerializableStatefulConsumer(
-                () -> new AdvancedStateConsumer("counter", outputRate, stateSizeBytes, initCountRandom, initCountSeed));
+                smallRyeConfig != null
+                        ? smallRyeConfig.getOptionalValues("matcher.selectivities", Double.class, Integer.class).orElse(null)
+                        : null;
+        final double totalSelectivity = getRequiredDouble(config, "matcher.zipf.total.selectivity");
+        final int numRules = getRequiredInt(config, "matcher.zipf.num.rules");
+        final double s = getRequiredDouble(config, "matcher.zipf.s");
+        final int outputRate = getRequiredInt(config, "consumer.output.rate");
+        final int stateSizeBytes = getRequiredInt(config, "consumer.state.size.bytes");
+        final boolean initCountRandom = getRequiredBoolean(config, "consumer.init.count.random");
+        final long initCountSeed = getRequiredLong(config, "consumer.init.count.seed");
 
         Dataset<Tuple2<String, TimestampedRecord>> streamingWithKeys = kafkaStream
                 .as(Encoders.tuple(Encoders.BINARY(), Encoders.TIMESTAMP()))
                 .map(
-                        (MapFunction<Tuple2<byte[], Timestamp>, TimestampedRecord>) timestampedArray -> new TimestampedRecord(timestampedArray._2.getTime(), timestampedArray._1),
+                        (MapFunction<Tuple2<byte[], Timestamp>, TimestampedRecord>) timestampedArray ->
+                                new TimestampedRecord(timestampedArray._2.getTime(), timestampedArray._1),
+                        // If Kryo still gives trouble here, switch to javaSerialization
                         Encoders.kryo(TimestampedRecord.class)
-                ).flatMap((FlatMapFunction<TimestampedRecord, Tuple2<String, TimestampedRecord>>)
-                            x -> {
-                                // return matcherService.match(x)
-                                //        .stream()
-                                //        .map(entry -> new Tuple2<>(entry.getKey(), entry.getValue()))
-                                //        .iterator();
-                                List<Tuple2<String, TimestampedRecord>> tuples = new ArrayList<>();
-                                Collection<Map.Entry<String, TimestampedRecord>> entries = matcherService.match(x);
-                                for (Map.Entry<String, TimestampedRecord> entry : entries) {
-                                    tuples.add(new Tuple2<>(entry.getKey(), entry.getValue()));
-                                }
-                                return tuples.iterator();
-                            },
-                    Encoders.tuple(Encoders.STRING(), Encoders.kryo(TimestampedRecord.class))
+                        // Encoders.javaSerialization(TimestampedRecord.class)
+                )
+                .flatMap(
+                        new MatcherFlatMapFunction(selectivities, totalSelectivity, numRules, s),
+                        Encoders.tuple(Encoders.STRING(),
+                                // Same note: switch to javaSerialization if needed
+                                Encoders.kryo(TimestampedRecord.class))
+                        // Encoders.tuple(Encoders.STRING(), Encoders.javaSerialization(TimestampedRecord.class))
                 );
 
-        FlatMapGroupsWithStateFunction<String, Tuple2<String, TimestampedRecord>, State, Tuple2<String, ConsumerEvent>> updateState = (key, values, state) -> {
-            // Maybe the exists() check is unnecessary here, as the consumer can
-            final State consumerState = state.exists() ? state.get() : new State();
-            final List<Tuple2<String, ConsumerEvent>> forwardEvents = new ArrayList<>();
-            while (values.hasNext()) {
-                final Tuple2<String, TimestampedRecord> recordWithKey = values.next();
-                final ConsumerResult consumerResult = consumer.accept(recordWithKey._2, consumerState);
-                // Might be possible to move the update out of the loop,
-                // but don't know about impact on processing guarantees/fault tolerance
-                state.update(consumerResult.getState());
-                consumerResult.getEvent().ifPresent(event -> forwardEvents.add(new Tuple2<>(key, event)));
-            }
-            return forwardEvents.iterator();
-        };
-
         Dataset<Tuple2<String, byte[]>> statefulAggregation = streamingWithKeys
-                //.as(Encoders.tuple(Encoders.STRING(), Encoders.kryo(TimestampedRecord.class)))
-                .groupByKey((MapFunction<Tuple2<String, TimestampedRecord>, String>) value -> value._1, Encoders.STRING())
+                .groupByKey(
+                        (MapFunction<Tuple2<String, TimestampedRecord>, String>) value -> value._1,
+                        Encoders.STRING()
+                )
                 .flatMapGroupsWithState(
-                        updateState,
+                        new StatefulUpdateFunction(outputRate, stateSizeBytes, initCountRandom, initCountSeed),
                         OutputMode.Update(),
-                        Encoders.kryo(State.class),
-                        Encoders.tuple(Encoders.STRING(), Encoders.kryo(ConsumerEvent.class)),
-                        GroupStateTimeout.NoTimeout())
+                        // IMPORTANT: use Java serialization for state encoder
+                        Encoders.javaSerialization(State.class),
+                        // IMPORTANT: use Java serialization for the ConsumerEvent in the output tuple
+                        Encoders.tuple(Encoders.STRING(), Encoders.javaSerialization(ConsumerEvent.class)),
+                        GroupStateTimeout.NoTimeout()
+                )
                 .map(
-                        (MapFunction<Tuple2<String, ConsumerEvent>, Tuple2<String, byte[]>>) stateWithKey -> new Tuple2<>(stateWithKey._1, stateWithKey._2.getData()),
-                        Encoders.tuple(Encoders.STRING(), Encoders.BINARY()));
+                        (MapFunction<Tuple2<String, ConsumerEvent>, Tuple2<String, byte[]>>)
+                                stateWithKey -> new Tuple2<>(stateWithKey._1, stateWithKey._2.getData()),
+                        Encoders.tuple(Encoders.STRING(), Encoders.BINARY())
+                );
 
-        StreamingQuery query =  statefulAggregation
+        DataStreamWriter<Row> writer = statefulAggregation
                 .toDF("key", "value")
                 .writeStream()
                 .outputMode(OutputMode.Update())
                 .format("kafka")
                 .option("kafka.bootstrap.servers", kafkaBootstrapServers)
                 .option("topic", kafkaOutputTopic)
-                .option("checkpointLocation", "/tmp/spark/checkpoint") //saves the checkpoints on /tmp/spark
-                .start();
+                .option("checkpointLocation", "/tmp/spark/checkpoint");
+
+        Trigger trigger = createTrigger(sparkTriggerMode, sparkTriggerInterval);
+        if (trigger != null) {
+            writer = writer.trigger(trigger);
+        }
+        StreamingQuery query = writer.start();
+
+        System.out.println("App build marker: " + System.getenv("IMAGE_BUILD_ID"));
+
         query.awaitTermination();
+    }
+
+    /**
+     * Serializable FlatMap function for matching records.
+     * Uses transient field for MatcherService to avoid serialization issues.
+     */
+    private static class MatcherFlatMapFunction
+            implements FlatMapFunction<TimestampedRecord, Tuple2<String, TimestampedRecord>>, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Map<Double, Integer> selectivities;
+        private final double totalSelectivity;
+        private final int numRules;
+        private final double s;
+        private final long seed = 0x2e3fac4f58fc98b4L;
+
+        // Transient - will be initialized on each executor
+        private transient MatcherService<TimestampedRecord> matcherService;
+
+        public MatcherFlatMapFunction(Map<Double, Integer> selectivities,
+                                      double totalSelectivity,
+                                      int numRules,
+                                      double s) {
+            this.selectivities = selectivities;
+            this.totalSelectivity = totalSelectivity;
+            this.numRules = numRules;
+            this.s = s;
+        }
+
+        /**
+         * Lazy initialization of MatcherService on executor.
+         * This avoids serializing the service itself.
+         */
+        private MatcherService<TimestampedRecord> getMatcherService() {
+            if (matcherService == null) {
+                if (selectivities != null) {
+                    matcherService = SimpleMatcherService.createFromFrequencyMap(
+                            selectivities,
+                            seed
+                    );
+                } else {
+                    matcherService = SimpleMatcherService.createFromZipf(
+                            numRules,
+                            totalSelectivity,
+                            s,
+                            seed
+                    );
+                }
+            }
+            return matcherService;
+        }
+
+        @Override
+        public Iterator<Tuple2<String, TimestampedRecord>> call(TimestampedRecord record) throws Exception {
+            List<Tuple2<String, TimestampedRecord>> tuples = new ArrayList<>();
+            Collection<Map.Entry<String, TimestampedRecord>> entries = getMatcherService().match(record);
+
+            for (Map.Entry<String, TimestampedRecord> entry : entries) {
+                tuples.add(new Tuple2<>(entry.getKey(), entry.getValue()));
+            }
+
+            return tuples.iterator();
+        }
+    }
+
+    /**
+     * Serializable FlatMapGroupsWithState function for stateful processing.
+     * Uses transient field for StatefulConsumer to avoid serialization issues.
+     */
+    private static class StatefulUpdateFunction
+            implements FlatMapGroupsWithStateFunction<String,
+            Tuple2<String, TimestampedRecord>,
+            State,
+            Tuple2<String, ConsumerEvent>>,
+            Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int outputRate;
+        private final int stateSizeBytes;
+        private final boolean initCountRandom;
+        private final long initCountSeed;
+
+        // Transient - will be initialized on each executor
+        private transient StatefulConsumer consumer;
+
+        public StatefulUpdateFunction(int outputRate,
+                                      int stateSizeBytes,
+                                      boolean initCountRandom,
+                                      long initCountSeed) {
+            this.outputRate = outputRate;
+            this.stateSizeBytes = stateSizeBytes;
+            this.initCountRandom = initCountRandom;
+            this.initCountSeed = initCountSeed;
+        }
+
+        /**
+         * Lazy initialization of StatefulConsumer on executor.
+         * This avoids serializing the consumer itself.
+         */
+        private StatefulConsumer getConsumer() {
+            if (consumer == null) {
+                consumer = new AdvancedStateConsumer(
+                        "counter",
+                        outputRate,
+                        stateSizeBytes,
+                        initCountRandom,
+                        initCountSeed
+                );
+            }
+            return consumer;
+        }
+
+        @Override
+        public Iterator<Tuple2<String, ConsumerEvent>> call(
+                String key,
+                Iterator<Tuple2<String, TimestampedRecord>> values,
+                GroupState<State> state) throws Exception {
+
+            // Get or create state
+            final State consumerState = state.exists() ? state.get() : new State();
+            final List<Tuple2<String, ConsumerEvent>> forwardEvents = new ArrayList<>();
+
+            // Process all values for this key
+            while (values.hasNext()) {
+                final Tuple2<String, TimestampedRecord> recordWithKey = values.next();
+                final ConsumerResult consumerResult = getConsumer().accept(recordWithKey._2, consumerState);
+
+                // Update state after each record
+                state.update(consumerResult.getState());
+
+                // Add event if present
+                consumerResult.getEvent().ifPresent(event ->
+                        forwardEvents.add(new Tuple2<>(key, event))
+                );
+            }
+
+            return forwardEvents.iterator();
+        }
+    }
+
+    private static Config loadMicroProfileConfig() {
+        boolean useMpConfig = Boolean.parseBoolean(System.getenv("USE_MICROPROFILE_CONFIG"));
+        if (!useMpConfig) {
+            System.out.println("USE_MICROPROFILE_CONFIG not set; using environment variables.");
+            return null;
+        }
+        try {
+            return ConfigProviderResolver.instance().getConfig();
+        } catch (Throwable t) {
+            System.out.println("MicroProfile Config not available, falling back to environment variables.");
+            return null;
+        }
+    }
+
+    private static SmallRyeConfig tryUnwrapSmallRye(Config config) {
+        if (config == null) {
+            return null;
+        }
+        try {
+            return config.unwrap(SmallRyeConfig.class);
+        } catch (Throwable t) {
+            System.out.println("SmallRyeConfig not available; continuing without it.");
+            return null;
+        }
+    }
+
+    private static String getRequiredString(Config config, String key) {
+        if (config != null) {
+            return config.getValue(key, String.class);
+        }
+        return getRequiredEnv(key);
+    }
+
+    private static int getRequiredInt(Config config, String key) {
+        if (config != null) {
+            return config.getValue(key, Integer.class);
+        }
+        return Integer.parseInt(getRequiredEnv(key));
+    }
+
+    private static long getRequiredLong(Config config, String key) {
+        if (config != null) {
+            return config.getValue(key, Long.class);
+        }
+        return Long.parseLong(getRequiredEnv(key));
+    }
+
+    private static double getRequiredDouble(Config config, String key) {
+        if (config != null) {
+            return config.getValue(key, Double.class);
+        }
+        return Double.parseDouble(getRequiredEnv(key));
+    }
+
+    private static boolean getRequiredBoolean(Config config, String key) {
+        if (config != null) {
+            return config.getValue(key, Boolean.class);
+        }
+        return Boolean.parseBoolean(getRequiredEnv(key));
+    }
+
+    private static Optional<Integer> getOptionalInt(Config config, String key) {
+        if (config != null) {
+            return config.getOptionalValue(key, Integer.class);
+        }
+        String val = System.getenv(toEnvKey(key));
+        return (val == null || val.isBlank()) ? Optional.empty() : Optional.of(Integer.parseInt(val));
+    }
+
+    private static Optional<String> getOptionalString(Config config, String key) {
+        if (config != null) {
+            return config.getOptionalValue(key, String.class);
+        }
+        String val = System.getenv(toEnvKey(key));
+        return (val == null || val.isBlank()) ? Optional.empty() : Optional.of(val);
+    }
+
+    /**
+     * Create a Spark streaming trigger based on the configured mode.
+     * Supported modes: "default" (Spark micro-batch, no explicit trigger),
+     * "processing", "continuous", "realtime".
+     * Returns {@code null} for the "default" mode so the caller can skip
+     * calling {@code .trigger(...)} on the writer.
+     */
+    private static Trigger createTrigger(String mode, String interval) {
+        switch (mode.toLowerCase(Locale.ROOT)) {
+            case "default":
+            case "":
+                System.out.println("Using Spark default (micro-batch) trigger");
+                return null;
+            case "processing":
+                requireInterval(mode, interval);
+                System.out.println("Using ProcessingTime trigger with interval: " + interval);
+                return Trigger.ProcessingTime(interval);
+            case "continuous":
+                requireInterval(mode, interval);
+                System.out.println("Using Continuous trigger with interval: " + interval);
+                return Trigger.Continuous(interval);
+            case "realtime":
+                requireInterval(mode, interval);
+                System.out.println("Using RealTime trigger with interval: " + interval);
+                return Trigger.RealTime(interval);
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown spark.trigger.mode: '" + mode + "'. "
+                                + "Expected one of: default, processing, continuous, realtime.");
+        }
+    }
+
+    private static void requireInterval(String mode, String interval) {
+        if (interval == null || interval.isBlank()) {
+            throw new IllegalStateException(
+                    "spark.trigger.mode='" + mode + "' requires spark.trigger.interval "
+                            + "(or legacy spark.trigger.realtime) to be set.");
+        }
+    }
+
+    private static String getRequiredEnv(String key) {
+        String envKey = toEnvKey(key);
+        String val = System.getenv(envKey);
+        if (val == null || val.isBlank()) {
+            throw new IllegalStateException("Missing config: " + key + " (env " + envKey + ")");
+        }
+        return val;
+    }
+
+    private static String toEnvKey(String key) {
+        return key.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_');
     }
 }

--- a/shuffle-spark/src/main/resources/META-INF/microprofile-config.properties
+++ b/shuffle-spark/src/main/resources/META-INF/microprofile-config.properties
@@ -1,6 +1,13 @@
 kafka.bootstrap.servers=localhost:9092
 kafka.topic.input=input
 kafka.topic.output=output
+# Trigger configuration. Default mode is Spark's micro-batch ("default"), which
+# does not need an interval. To enable realtime mode, set:
+#   spark.trigger.mode=realtime
+#   spark.trigger.interval=200 milliseconds
+# Other supported modes: processing, continuous (also require spark.trigger.interval).
+#spark.trigger.mode=default
+#spark.trigger.interval=200 milliseconds
 #spark.max.offsets.per.trigger=100000
 #spark.state.store.provider=org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
 matcher.zipf.num.rules=1000


### PR DESCRIPTION
This builds on top of #4 and adds:

1. shuffle-flink: upgrade to Flink 2.0 on Java 21
2. shuffle-spark: upgrade to Spark 4.1 on Java 21
3. Kubernetes: small fixes needed to run on modern EKS / K8s
   (EBS CSI provisioner; Strimzi CRD/JVM-options compat)